### PR TITLE
Prepend header w/ timestamp to output

### DIFF
--- a/healthcheck
+++ b/healthcheck
@@ -1425,6 +1425,8 @@ def showsummary
   print colorize(:off)
 end
 
+puts colorize(:redbg) + 'Magento Healthcheck - System time is ' + Time.now.to_s + colorize(:off) + "\n\n"
+
 if Process.uid != 0
     puts colorize(:redbg) + "Not running as root.  May not be able to get all info." + colorize(:off)
 end


### PR DESCRIPTION
This will help distinguish multiple runs of the script.  The timestamp will also show what the local system time is, which allows easier correlation of logged events across systems.
